### PR TITLE
Print usage instead of panic for no arguments

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -302,7 +302,8 @@ func (c *SubCmd) ArgsVar(value ArgsValue, usage, details string, options ...pred
 
 func (c *SubCmd) parse(args []string) ([]string, error) {
 	if len(args) < 1 {
-		panic("must be at least the command in arguments")
+		c.Usage()
+		return nil, flag.ErrHelp
 	}
 
 	c.checkFlagsTree(make(map[string]bool))

--- a/cmd.go
+++ b/cmd.go
@@ -313,6 +313,7 @@ func (c *SubCmd) parse(args []string) ([]string, error) {
 	// If command has sub commands, find it and parse the sub command.
 	if len(c.sub) > 0 {
 		if len(args) == 0 {
+			c.Usage()
 			return nil, fmt.Errorf("must provide sub command")
 		}
 		name := args[0]

--- a/cmd.go
+++ b/cmd.go
@@ -302,8 +302,7 @@ func (c *SubCmd) ArgsVar(value ArgsValue, usage, details string, options ...pred
 
 func (c *SubCmd) parse(args []string) ([]string, error) {
 	if len(args) < 1 {
-		c.Usage()
-		return nil, flag.ErrHelp
+		panic("must be at least the command in arguments")
 	}
 
 	c.checkFlagsTree(make(map[string]bool))
@@ -311,7 +310,7 @@ func (c *SubCmd) parse(args []string) ([]string, error) {
 	// First argument is the command name.
 	args = args[1:]
 
-	/// If command has sub commands, find it and parse the sub command.
+	// If command has sub commands, find it and parse the sub command.
 	if len(c.sub) > 0 {
 		if len(args) == 0 {
 			return nil, fmt.Errorf("must provide sub command")

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -394,4 +394,13 @@ func TestCmd_failures(t *testing.T) {
 
 		assert.Panics(t, func() { root.Args("", "") })
 	})
+
+	t.Run("calling without sub commands fails with usage", func(t *testing.T) {
+		root := New(OptOutput(ioutil.Discard), OptErrorHandling(flag.ContinueOnError))
+		root.SubCommand("sub1", "")
+
+		if err := root.ParseArgs("cmd"); assert.Error(t, err) {
+			assert.EqualError(t, err, "must provide sub command")
+		}
+	})
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -289,7 +290,7 @@ func TestCmd_valueCheck(t *testing.T) {
 
 		assert.NoError(t, root.ParseArgs("cmd", "-file", "cmd.go"))
 		assert.NoError(t, root.ParseArgs("cmd", "-file", "./cmd.go"))
-		assert.NoError(t, root.ParseArgs("cmd", "-file", "example/main.go"))
+		assert.NoError(t, root.ParseArgs("cmd", "-file", filepath.Join("example", "main.go")))
 		assert.Error(t, root.ParseArgs("cmd", "-file", "no-such-file.go"))
 		assert.Error(t, root.ParseArgs("cmd", "-file", "README.md"))
 
@@ -323,7 +324,7 @@ func TestCmd_failures(t *testing.T) {
 	})
 
 	t.Run("parse must get at least one argument", func(t *testing.T) {
-		root := New(OptOutput(ioutil.Discard))
+		root := New(OptOutput(ioutil.Discard), OptErrorHandling(flag.PanicOnError))
 
 		assert.Panics(t, func() { root.ParseArgs() })
 	})

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -324,7 +324,7 @@ func TestCmd_failures(t *testing.T) {
 	})
 
 	t.Run("parse must get at least one argument", func(t *testing.T) {
-		root := New(OptOutput(ioutil.Discard), OptErrorHandling(flag.PanicOnError))
+		root := New(OptOutput(ioutil.Discard))
 
 		assert.Panics(t, func() { root.ParseArgs() })
 	})

--- a/example/main.go
+++ b/example/main.go
@@ -23,13 +23,13 @@ var (
 )
 
 func main() {
-	root.ParseArgs()
+	_=	root.Parse()
 
-	// Check which sub command was choses by the user.
+	// Check which sub command was chosen by the user.
 	switch {
 	case sub1.Parsed():
-		fmt.Printf("Called sub1 with flag: %s", *flag1)
+		fmt.Printf("Called sub1 with flags: %s", *flag1)
 	case sub2.Parsed():
-		fmt.Printf("Called sub2 with flag: %d", *flag2)
+		fmt.Printf("Called sub2 with flags: %d", *flag2)
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -23,13 +23,13 @@ var (
 )
 
 func main() {
-	_=	root.Parse()
+	_= root.Parse()
 
 	// Check which sub command was chosen by the user.
 	switch {
 	case sub1.Parsed():
-		fmt.Printf("Called sub1 with flags: %s", *flag1)
+		fmt.Printf("Called sub1 with flag: %s", *flag1)
 	case sub2.Parsed():
-		fmt.Printf("Called sub2 with flags: %d", *flag2)
+		fmt.Printf("Called sub2 with flag: %d", *flag2)
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -23,7 +23,7 @@ var (
 )
 
 func main() {
-	_= root.Parse()
+	root.Parse()
 
 	// Check which sub command was chosen by the user.
 	switch {


### PR DESCRIPTION
Previously, if no arguments were passed to the root command, a panic was triggered which in turn bypassed the error handling strategy. Also the provided message was not really helpful to the user.

With this commit the usage is printed instead. Additionally, an error is returned which is correctly handled by the error handling strategy.