### PR TITLE
Add option to disable completion in usage

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -117,9 +117,9 @@ func (f ArgsFn) Set(args []string) error { return f(args) }
 // config is configuration for root command.
 type config struct {
 	subConfig
-	name              string
-	errorHandling     flag.ErrorHandling
-	output            io.Writer
+	name          string
+	errorHandling flag.ErrorHandling
+	output        io.Writer
 }
 
 // subConfig is configuration that used both for root command and sub commands.
@@ -190,9 +190,9 @@ func OptDetails(details string) optionFn {
 func New(options ...optionRoot) *Cmd {
 	// Set default config.
 	cfg := config{
-		name:              os.Args[0],
-		errorHandling:     flag.ExitOnError,
-		output:            os.Stderr,
+		name:          os.Args[0],
+		errorHandling: flag.ExitOnError,
+		output:        os.Stderr,
 	}
 	// Update with requested options.
 	for _, option := range options {

--- a/cmd.go
+++ b/cmd.go
@@ -120,7 +120,6 @@ type config struct {
 	name              string
 	errorHandling     flag.ErrorHandling
 	output            io.Writer
-	completionEnabled bool
 }
 
 // subConfig is configuration that used both for root command and sub commands.
@@ -194,7 +193,6 @@ func New(options ...optionRoot) *Cmd {
 		name:              os.Args[0],
 		errorHandling:     flag.ExitOnError,
 		output:            os.Stderr,
-		completionEnabled: detectCompletionSupport(),
 	}
 	// Update with requested options.
 	for _, option := range options {
@@ -410,7 +408,7 @@ func (c *SubCmd) Usage() {
 		}
 		fmt.Fprintf(w, "\n")
 		// Print completion options only to the root command.
-		if c.isRoot && c.completionEnabled {
+		if c.isRoot && detectCompletionSupport() {
 			fmt.Fprintln(w, completionUsage(c.name))
 		}
 	} else {
@@ -499,12 +497,8 @@ func copyFlagSet(cfg config, f *compflag.FlagSet) *compflag.FlagSet {
 }
 
 func detectCompletionSupport() bool {
-	if shellPath, ok := os.LookupEnv("SHELL"); ok {
-		shellName := strings.ToLower(filepath.Base(shellPath))
-		return shellName == "bash" || shellName == "fish" || shellName == "zsh"
-	}
-
-	return false
+	shellName := strings.ToLower(filepath.Base(os.Getenv("SHELL")))
+	return shellName == "bash" || shellName == "fish" || shellName == "zsh"
 }
 
 func completionUsage(name string) string {

--- a/cmd.go
+++ b/cmd.go
@@ -123,8 +123,9 @@ type config struct {
 
 // subConfig is configuration that used both for root command and sub commands.
 type subConfig struct {
-	synopsis string
-	details  string
+	synopsis           string
+	details            string
+	completionDisabled bool
 }
 
 // optionRoot is an option that can be applied only on the root command and not on sub commands.
@@ -182,6 +183,12 @@ func OptSynopsis(synopsis string) optionRootFn {
 func OptDetails(details string) optionFn {
 	return func(cfg *subConfig) {
 		cfg.details = details
+	}
+}
+
+func OptCompletion(completionDisabled bool) optionFn {
+	return func(cfg *subConfig) {
+		cfg.completionDisabled = completionDisabled
 	}
 }
 
@@ -407,7 +414,7 @@ func (c *SubCmd) Usage() {
 		}
 		fmt.Fprintf(w, "\n")
 		// Print completion options only to the root command.
-		if c.isRoot {
+		if c.isRoot && !c.completionDisabled {
 			fmt.Fprintln(w, completionUsage(c.name))
 		}
 	} else {

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -146,8 +146,6 @@ func TestSubCmd(t *testing.T) {
 }
 
 func TestHelp(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		shell string
 		args []string
@@ -314,6 +312,8 @@ Flags:
 
 	for _, tt := range tests {
 		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			previousShell := os.Getenv("SHELL")
+			defer os.Setenv("SHELL", previousShell)
 			require.NoError(t, os.Setenv("SHELL", tt.shell))
 
 			root := newTestCmd()

--- a/complete_test.go
+++ b/complete_test.go
@@ -9,7 +9,7 @@ import (
 func TestComplete(t *testing.T) {
 	t.Parallel()
 
-	comp := (*completer)(newTestCmd(false).SubCmd)
+	comp := (*completer)(newTestCmd().SubCmd)
 
 	tests := []struct {
 		line        string

--- a/complete_test.go
+++ b/complete_test.go
@@ -9,7 +9,7 @@ import (
 func TestComplete(t *testing.T) {
 	t.Parallel()
 
-	comp := (*completer)(newTestCmd().SubCmd)
+	comp := (*completer)(newTestCmd(false).SubCmd)
 
 	tests := []struct {
 		line        string


### PR DESCRIPTION
For some use-cases or operation systems, it might not be desirable to print usage information. That is why this commit introduces an option to disable completion information.

This addresses issue #20