### PR TITLE
Fixed typo in example 1, subcommand 2 example and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ var (
 
 	// Define a second sub command from the root command with an int flag.
 	sub2  = root.SubCommand("sub2", "second sub command")
-	flag2 = sub1.Int("flag2", 0, "sub2 int flag")
+	flag2 = sub2.Int("flag2", 0, "sub2 int flag")
 )
 
 // Definition and usage of sub commands and sub commands flags.

--- a/example_1_subcommand_test.go
+++ b/example_1_subcommand_test.go
@@ -19,7 +19,7 @@ var (
 
 	// Define a second sub command from the root command with an int flag.
 	sub2  = root.SubCommand("sub2", "second sub command")
-	flag2 = sub1.Int("flag2", 0, "sub2 int flag")
+	flag2 = sub2.Int("flag2", 0, "sub2 int flag")
 )
 
 // Definition and usage of sub commands and sub commands flags.


### PR DESCRIPTION
Line 22 in the example shows:

```
flag2 = sub1.Int("flag2", 0, "sub2 int flag")
```

But it should really be:

```
flag2 = sub2.Int("flag2", 0, "sub2 int flag")
```